### PR TITLE
fix: Adding tox.ini path to tox command in Dockerfile

### DIFF
--- a/template/python3-flask-armhf/Dockerfile
+++ b/template/python3-flask-armhf/Dockerfile
@@ -36,7 +36,7 @@ USER root
 COPY function   function
 RUN chown -R app:app ./
 
-ARG TEST_COMMAND=tox
+ARG TEST_COMMAND="tox -c function/tox.ini"
 ARG TEST_ENABLED=true
 RUN if [ "$TEST_ENABLED" == "false" ]; then \
     echo "skipping tests";\

--- a/template/python3-flask-debian/Dockerfile
+++ b/template/python3-flask-debian/Dockerfile
@@ -42,7 +42,7 @@ USER root
 COPY function   function
 RUN chown -R app:app ./
 
-ARG TEST_COMMAND=tox
+ARG TEST_COMMAND="tox -c function/tox.ini"
 ARG TEST_ENABLED=true
 RUN if [ "$TEST_ENABLED" == "false" ]; then \
     echo "skipping tests";\

--- a/template/python3-flask/Dockerfile
+++ b/template/python3-flask/Dockerfile
@@ -40,7 +40,7 @@ USER root
 COPY function/   .
 RUN chown -R app:app ../
 
-ARG TEST_COMMAND=tox
+ARG TEST_COMMAND="tox -c function/tox.ini"
 ARG TEST_ENABLED=true
 RUN if [ "$TEST_ENABLED" == "false" ]; then \
     echo "skipping tests";\

--- a/template/python3-http-armhf/Dockerfile
+++ b/template/python3-http-armhf/Dockerfile
@@ -34,7 +34,7 @@ USER root
 COPY function   function
 RUN chown -R app:app ./
 
-ARG TEST_COMMAND=tox
+ARG TEST_COMMAND="tox -c function/tox.ini"
 ARG TEST_ENABLED=true
 RUN if [ "$TEST_ENABLED" == "false" ]; then \
     echo "skipping tests";\

--- a/template/python3-http-debian/Dockerfile
+++ b/template/python3-http-debian/Dockerfile
@@ -37,7 +37,7 @@ USER root
 COPY function   function
 RUN chown -R app:app ./
 
-ARG TEST_COMMAND=tox
+ARG TEST_COMMAND="tox -c function/tox.ini"
 ARG TEST_ENABLED=true
 RUN if [ "$TEST_ENABLED" == "false" ]; then \
     echo "skipping tests";\

--- a/template/python3-http/Dockerfile
+++ b/template/python3-http/Dockerfile
@@ -40,7 +40,7 @@ USER root
 COPY function   function
 RUN chown -R app:app ./
 
-ARG TEST_COMMAND=tox
+ARG TEST_COMMAND="tox -c function/tox.ini"
 ARG TEST_ENABLED=true
 RUN if [ "$TEST_ENABLED" == "false" ]; then \
     echo "skipping tests";\


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
tox.ini file path is not mentioned in tox command , and the file is not in the current working directory due to which tox command fails to find the config file. This change adds the path to tox command and specifies the tox.ini config file path which would resole this issue.

## Motivation and Context
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label
Issue #44

## How Has This Been Tested?
Tested with - 
1. No test cases 
2. one or more test cases 
No change in existing functionality

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
