### PR TITLE
fix: tox config file as in sub directory correcting WORKDIR

### DIFF
--- a/template/python3-flask-armhf/Dockerfile
+++ b/template/python3-flask-armhf/Dockerfile
@@ -30,11 +30,9 @@ WORKDIR /home/app/function/
 COPY function/requirements.txt	.
 RUN pip install --user -r requirements.txt
 
-WORKDIR /home/app/
-
 USER root
-COPY function   function
-RUN chown -R app:app ./
+COPY function/   .
+RUN chown -R app:app ../
 
 ARG TEST_COMMAND=tox
 ARG TEST_ENABLED=true
@@ -43,6 +41,8 @@ RUN if [ "$TEST_ENABLED" == "false" ]; then \
     else \
     eval "$TEST_COMMAND"; \
     fi
+
+WORKDIR /home/app/
 
 USER app
 

--- a/template/python3-flask-debian/Dockerfile
+++ b/template/python3-flask-debian/Dockerfile
@@ -34,13 +34,11 @@ WORKDIR /home/app/function/
 COPY function/requirements.txt	.
 RUN pip install --user -r requirements.txt
 
-WORKDIR /home/app/
-
 #install function code
 USER root
 
-COPY function   function
-RUN chown -R app:app ./
+COPY function/   .
+RUN chown -R app:app ../
 
 ARG TEST_COMMAND=tox
 ARG TEST_ENABLED=true
@@ -49,6 +47,8 @@ RUN if [ "$TEST_ENABLED" == "false" ]; then \
     else \
     eval "$TEST_COMMAND"; \
     fi
+
+WORKDIR /home/app/
 
 #configure WSGI server and healthcheck
 USER app

--- a/template/python3-http-armhf/Dockerfile
+++ b/template/python3-http-armhf/Dockerfile
@@ -28,11 +28,9 @@ WORKDIR /home/app/function/
 COPY function/requirements.txt	.
 RUN pip install --user -r requirements.txt
 
-WORKDIR /home/app/
-
 USER root
-COPY function   function
-RUN chown -R app:app ./
+COPY function/   .
+RUN chown -R app:app ../
 
 ARG TEST_COMMAND=tox
 ARG TEST_ENABLED=true
@@ -41,6 +39,8 @@ RUN if [ "$TEST_ENABLED" == "false" ]; then \
     else \
     eval "$TEST_COMMAND"; \
     fi
+
+WORKDIR /home/app/
 
 USER app
 

--- a/template/python3-http-debian/Dockerfile
+++ b/template/python3-http-debian/Dockerfile
@@ -31,11 +31,9 @@ WORKDIR /home/app/function/
 COPY function/requirements.txt	.
 RUN pip install --user -r requirements.txt
 
-WORKDIR /home/app/
-
 USER root
-COPY function   function
-RUN chown -R app:app ./
+COPY function/   .
+RUN chown -R app:app ../
 
 ARG TEST_COMMAND=tox
 ARG TEST_ENABLED=true
@@ -44,6 +42,8 @@ RUN if [ "$TEST_ENABLED" == "false" ]; then \
     else \
     eval "$TEST_COMMAND"; \
     fi
+
+WORKDIR /home/app/
 
 USER app
 

--- a/template/python3-http/Dockerfile
+++ b/template/python3-http/Dockerfile
@@ -33,12 +33,10 @@ WORKDIR /home/app/function/
 COPY function/requirements.txt	.
 RUN pip install --user -r requirements.txt
 
-WORKDIR /home/app/
-
 #install function code
 USER root
-COPY function   function
-RUN chown -R app:app ./
+COPY function/   .
+RUN chown -R app:app ../
 
 ARG TEST_COMMAND=tox
 ARG TEST_ENABLED=true
@@ -47,6 +45,8 @@ RUN if [ "$TEST_ENABLED" == "false" ]; then \
     else \
     eval "$TEST_COMMAND"; \
     fi
+
+WORKDIR /home/app/
 
 #configure WSGI server and healthcheck
 USER app


### PR DESCRIPTION
Signed-off-by: saikiran <neo2603@gmail.com>

Tox config is not in the directory from where tox command is executed, moved WORKDIR change which was happening before test to after , this ensures tox executes from inside the function folder.
## Description
moved WORKDIR command after the test execution , modified copy and chown command to execute properly from new WORKDIR
## Motivation and Context
helps fix issue #44 
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label


## How Has This Been Tested?
tested with creating new function and executing faas build.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
