### PR TITLE
feat: user multi-stage builds and remove apt and pip caches

### DIFF
--- a/template/python27-flask/Dockerfile
+++ b/template/python27-flask/Dockerfile
@@ -1,5 +1,5 @@
 FROM ghcr.io/openfaas/of-watchdog:0.9.3 as watchdog
-FROM python:2.7-alpine
+FROM python:2.7-alpine as builder
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
@@ -21,20 +21,22 @@ WORKDIR /home/app/
 COPY --chown=app:app index.py           .
 COPY --chown=app:app requirements.txt   .
 USER root
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 USER app
 
 RUN mkdir -p function
 RUN touch ./function/__init__.py
 WORKDIR /home/app/function/
 COPY --chown=app:app function/requirements.txt	.
-RUN pip install --user -r requirements.txt
+RUN pip install --no-cache-dir --user -r requirements.txt
 
 WORKDIR /home/app/
 
 USER root
 COPY --chown=app:app function   function
 USER app
+
+FROM builder as final
 
 ENV fprocess="python index.py"
 ENV cgi_headers="true"

--- a/template/python3-flask-debian/Dockerfile
+++ b/template/python3-flask-debian/Dockerfile
@@ -7,7 +7,9 @@ RUN chmod +x /usr/bin/fwatchdog
 ARG ADDITIONAL_PACKAGE
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 
-RUN apt-get -qy update && apt-get -qy install gcc make ${ADDITIONAL_PACKAGE}
+RUN apt-get -qy update \
+    && apt-get -qy install gcc make ${ADDITIONAL_PACKAGE} \
+    && rm -rf /var/lib/apt/lists/*
 
 # Add non root user
 RUN addgroup --system app && adduser app --system --ingroup app
@@ -23,7 +25,7 @@ COPY --chown=app:app index.py           .
 COPY --chown=app:app requirements.txt   .
 
 USER root
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Build the function directory and install any user-specified components
 USER app
@@ -32,17 +34,20 @@ RUN mkdir -p function
 RUN touch ./function/__init__.py
 WORKDIR /home/app/function/
 COPY --chown=app:app function/requirements.txt	.
-RUN pip install --user -r requirements.txt
+RUN pip install --no-cache-dir --user -r requirements.txt
 
 #install function code
 USER root
 
 COPY --chown=app:app function/   .
 
+FROM builder as tester
 ARG TEST_COMMAND=tox
 ARG TEST_ENABLED=true
 RUN [ "$TEST_ENABLED" = "false" ] && echo "skipping tests" || eval "$TEST_COMMAND"
 
+
+FROM builder as final
 WORKDIR /home/app/
 
 #configure WSGI server and healthcheck

--- a/template/python3-flask/Dockerfile
+++ b/template/python3-flask/Dockerfile
@@ -23,7 +23,7 @@ COPY --chown=app:app index.py           .
 COPY --chown=app:app requirements.txt   .
 
 USER root
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Build the function directory and install any user-specified components
 USER app
@@ -32,17 +32,20 @@ RUN mkdir -p function
 RUN touch ./function/__init__.py
 WORKDIR /home/app/function/
 COPY --chown=app:app function/requirements.txt	.
-RUN pip install --user -r requirements.txt
+RUN pip install --no-cache-dir --user -r requirements.txt
 
 #install function code
 USER root
 
 COPY --chown=app:app function/   .
 
+
+FROM builder as tester
 ARG TEST_COMMAND=tox
 ARG TEST_ENABLED=true
 RUN [ "$TEST_ENABLED" = "false" ] && echo "skipping tests" || eval "$TEST_COMMAND"
 
+FROM builder as final
 WORKDIR /home/app/
 
 #configure WSGI server and healthcheck

--- a/template/python3-http-debian/Dockerfile
+++ b/template/python3-http-debian/Dockerfile
@@ -7,7 +7,9 @@ RUN chmod +x /usr/bin/fwatchdog
 ARG ADDITIONAL_PACKAGE
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 
-RUN apt-get -qy update && apt-get -qy install ${ADDITIONAL_PACKAGE}
+RUN apt-get -qy update \
+    && apt-get -qy install ${ADDITIONAL_PACKAGE} \
+    && rm -rf /var/lib/apt/lists/*
 
 # Add non root user
 RUN addgroup --system app && adduser app --system --ingroup app
@@ -22,22 +24,26 @@ WORKDIR /home/app/
 COPY --chown=app:app index.py           .
 COPY --chown=app:app requirements.txt   .
 USER root
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 USER app
 
 RUN mkdir -p function
 RUN touch ./function/__init__.py
 WORKDIR /home/app/function/
 COPY --chown=app:app function/requirements.txt	.
-RUN pip install --user -r requirements.txt
+RUN pip install --no-cache-dir --user -r requirements.txt
 
 USER root
 COPY --chown=app:app function/   .
+
+FROM builder as tester
 
 ARG TEST_COMMAND=tox
 ARG TEST_ENABLED=true
 RUN [ "$TEST_ENABLED" = "false" ] && echo "skipping tests" || eval "$TEST_COMMAND"
 
+
+FROM builder as final
 WORKDIR /home/app/
 
 USER app

--- a/template/python3-http/Dockerfile
+++ b/template/python3-http/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /home/app/
 COPY --chown=app:app index.py           .
 COPY --chown=app:app requirements.txt   .
 USER root
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Build the function directory and install any user-specified components
 USER app
@@ -31,16 +31,18 @@ RUN mkdir -p function
 RUN touch ./function/__init__.py
 WORKDIR /home/app/function/
 COPY --chown=app:app function/requirements.txt	.
-RUN pip install --user -r requirements.txt
+RUN pip install --no-cache-dir --user -r requirements.txt
 
 # install function code
 USER root
 COPY --chown=app:app function/   .
 
+FROM builder as tester
 ARG TEST_COMMAND=tox
 ARG TEST_ENABLED=true
 RUN [ "$TEST_ENABLED" = "false" ] && echo "skipping tests" || eval "$TEST_COMMAND"
 
+FROM builder as final
 WORKDIR /home/app/
 
 # configure WSGI server and healthcheck


### PR DESCRIPTION
Recreated for Hacktoberfest ;) 

1. Remove apt cache after running `apt-get`
2. Pass `--no-cache-dir` to the `pip` command
3. Use multi-stage builds to remove the test layers from the final image.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label

Resolves #57
Relates to #55

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```sh
$ faas-cli new echo0 --lang python3-flask 
$ faas-cli new echo1 --lang python3-http


$ faas-cli build -f echo0.yml --no-cache
# truncated
Image: echo0:latest built.
[0] < Building echo0 done in 37.65s.
[0] Worker done.

Total build time: 37.65s

$ faas-cli build -f echo1.yml --no-cache
# truncated
Image: echo1:latest built.
[0] < Building echo1 done in 32.50s.
[0] Worker done.

Total build time: 32.50s
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
