### PR TITLE
Drain connections for python3-http

### DIFF
--- a/template/python3-http/index.py
+++ b/template/python3-http/index.py
@@ -2,10 +2,19 @@
 from flask import Flask, request, jsonify
 from waitress import serve
 import os
+import sys
+
+import signal
 
 from function import handler
 
 app = Flask(__name__)
+
+def SignalHandler(SignalNumber, Frame):
+    timeout = os.getenv("write_timeout")
+
+    sys.stderr.write('Function got SIGTERM, draining for up to: {}\n'.format(timeout))
+    sys.stderr.flush()
 
 class Event:
     def __init__(self):
@@ -66,4 +75,7 @@ def call_handler(path):
     return resp
 
 if __name__ == '__main__':
+
+    signal.signal(signal.SIGTERM, SignalHandler)
+
     serve(app, host='0.0.0.0', port=5000)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Drain connections for python3-http

## Motivation and Context

When used with OpenFaaS Standard/Enterprise, the python3-http template's handler will now ignore SIGTERM allowing the watchdog and Kubernetes to handle the shutdown.

When there are ongoing requests, these will be processed before exiting.

When there are no ongoing requests, the function will exit immediately.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with OpenFaaS Standard a long running sleep function which went into a Terminating status. The function continued to execute its sleep for the whole duration, whilst the new replica came online and was ready in the meantime.

This is the same approach tested for the golang-http templates.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

No harm change. Being made for Kubiya who needed a graceful drain of long-running functions.

This is not new behaviour and is already used in the Go templates. Over time we will add it to all officially supported templates.

cc @shakedaskayo @koss110 @LucasRoesler 

I'll get this merged, if there is feedback, please let me know and I'll be happy to consider making changes from people who are more experienced with Python than myself.

https://github.com/openfaas/golang-http-template/blob/master/template/golang-middleware/main.go#L45

