### PR TITLE
Support multiple return types in the http-templates

### DIFF
--- a/template/python3-http-debian/index.py
+++ b/template/python3-http-debian/index.py
@@ -57,14 +57,17 @@ def get_content_type(res):
 def format_response(res):
     if res == None:
         return ('', 200)
+    
+    if type(resp) is dict:
+        statusCode = format_status_code(res)
+        content_type = get_content_type(res)
+        body = format_body(res, content_type)
 
-    statusCode = format_status_code(res)
-    content_type = get_content_type(res)
-    body = format_body(res, content_type)
+        headers = format_headers(res)
 
-    headers = format_headers(res)
+        return (body, statusCode, headers)
 
-    return (body, statusCode, headers)
+    return res
 
 @app.route('/', defaults={'path': ''}, methods=['GET', 'PUT', 'POST', 'PATCH', 'DELETE'])
 @app.route('/<path:path>', methods=['GET', 'PUT', 'POST', 'PATCH', 'DELETE'])

--- a/template/python3-http/index.py
+++ b/template/python3-http/index.py
@@ -48,12 +48,15 @@ def format_headers(resp):
 def format_response(resp):
     if resp == None:
         return ('', 200)
+    
+    if type(resp) is dict:
+        statusCode = format_status_code(resp)
+        body = format_body(resp)
+        headers = format_headers(resp)
 
-    statusCode = format_status_code(resp)
-    body = format_body(resp)
-    headers = format_headers(resp)
+        return (body, statusCode, headers)
 
-    return (body, statusCode, headers)
+    return resp
 
 @app.route('/', defaults={'path': ''}, methods=['GET', 'PUT', 'POST', 'PATCH', 'DELETE'])
 @app.route('/<path:path>', methods=['GET', 'PUT', 'POST', 'PATCH', 'DELETE'])


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Allow users to use the Flask `Response` object and other functions like `send_file`. This makes it possible to stream a response or return files.

For backwards compatibility the response is still formatted like before when a dict object type is returned by the handler.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label

Returning large files and binary response was not supported by the `python3-http` template.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually by converting a function example that creates a video-preview for a function using FFmpeg and returns the resulting video.

```python
import os
import json
import logging
import tempfile
import ffmpeg
from flask import send_file

from .preview import generate_video_preview, calculate_sample_seconds

debug = os.getenv("debug", "false").lower() == "true"

def handle(event, context):
    request_data = json.loads(event.body)

    data, status_code, message = parse_request(request_data)
    if data is None:
        return {
            "statusCode": status_code,
            "body": message
        }

    input_url = data["input_url"]
    sample_duration = data["sample_duration"]
    sample_seconds = data["sample_seconds"]
    scale = data["scale"]
    format = data["format"]

    out_file = tempfile.NamedTemporaryFile(delete=True)
    
    # Generate video preview
    try:
        generate_video_preview(input_url, out_file.name, sample_duration, sample_seconds, scale, format, quiet=not debug)
    except Exception as e:
        logging.error(e)
        return {
            "statusCode": 500,
            "body": "failed to generate video preview"
        }

    return send_file(out_file.name)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
