### PR TITLE
fix: ensure test layer is in the build DAG

### DIFF
--- a/template/python3-flask-debian/Dockerfile
+++ b/template/python3-flask-debian/Dockerfile
@@ -48,7 +48,7 @@ ARG TEST_ENABLED=true
 RUN [ "$TEST_ENABLED" = "false" ] && echo "skipping tests" || eval "$TEST_COMMAND"
 
 
-FROM build as ship
+FROM test as ship
 WORKDIR /home/app/
 
 #configure WSGI server and healthcheck

--- a/template/python3-flask/Dockerfile
+++ b/template/python3-flask/Dockerfile
@@ -46,7 +46,7 @@ ARG TEST_COMMAND=tox
 ARG TEST_ENABLED=true
 RUN [ "$TEST_ENABLED" = "false" ] && echo "skipping tests" || eval "$TEST_COMMAND"
 
-FROM build as ship
+FROM test as ship
 WORKDIR /home/app/
 
 #configure WSGI server and healthcheck

--- a/template/python3-http-debian/Dockerfile
+++ b/template/python3-http-debian/Dockerfile
@@ -44,7 +44,7 @@ ARG TEST_ENABLED=true
 RUN [ "$TEST_ENABLED" = "false" ] && echo "skipping tests" || eval "$TEST_COMMAND"
 
 
-FROM build as ship
+FROM test as ship
 WORKDIR /home/app/
 
 USER app

--- a/template/python3-http/Dockerfile
+++ b/template/python3-http/Dockerfile
@@ -43,7 +43,7 @@ ARG TEST_COMMAND=tox
 ARG TEST_ENABLED=true
 RUN [ "$TEST_ENABLED" = "false" ] && echo "skipping tests" || eval "$TEST_COMMAND"
 
-FROM build as ship
+FROM test as ship
 WORKDIR /home/app/
 
 # configure WSGI server and healthcheck


### PR DESCRIPTION
Some builders will exclude layers that do not contribute to the final target layer, meaning the `ship` layer for these templates. This means that the `test` layer is often optimized away by modern builders.

We add the `test` layer as a dependency of the `ship` layer to ensure it is always run.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [x] My issue has received approval from the maintainers or lead with the `design/approved` label

Resolves #71 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Yes, running docker build will now show the test layer in the output. This was also documented in the issue. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
