### PR TITLE
Add UPGRADE_PACKAGES for Debian-based templates

### DIFF
--- a/template/python3-flask-debian/Dockerfile
+++ b/template/python3-flask-debian/Dockerfile
@@ -1,5 +1,7 @@
 ARG PYTHON_VERSION=3.12
 ARG DEBIAN_OS=slim-bookworm
+ARG UPGRADE_PACKAGES=false
+
 FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.10.4 AS watchdog
 FROM --platform=${TARGETPLATFORM:-linux/amd64} python:${PYTHON_VERSION}-${DEBIAN_OS} AS build
 
@@ -9,8 +11,9 @@ RUN chmod +x /usr/bin/fwatchdog
 ARG ADDITIONAL_PACKAGE
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 
-RUN apt-get -qy update \
-    && apt-get -qy install gcc make ${ADDITIONAL_PACKAGE} \
+RUN apt-get update -qy \
+    && if [ "${UPGRADE_PACKAGES}" = "true" ] || [ "${UPGRADE_PACKAGES}" = "1" ]; then apt-get upgrade -qy; fi \
+    && apt-get install -qy --no-install-recommends gcc make ${ADDITIONAL_PACKAGE} \
     && rm -rf /var/lib/apt/lists/*
 
 # Add non root user

--- a/template/python3-flask/Dockerfile
+++ b/template/python3-flask/Dockerfile
@@ -5,12 +5,15 @@ FROM --platform=${TARGETPLATFORM:-linux/amd64} python:${PYTHON_VERSION}-alpine A
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
+ARG UPGRADE_PACKAGES=false
+
 ARG ADDITIONAL_PACKAGE
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 
-RUN apk --no-cache add openssl-dev ${ADDITIONAL_PACKAGE}
+RUN if [ "${UPGRADE_PACKAGES}" = "true" ] || [ "${UPGRADE_PACKAGES}" = "1" ]; then apk --no-cache upgrade; fi && \
+    apk --no-cache add openssl-dev ${ADDITIONAL_PACKAGE}
 
-# Add non root user
+    # Add non root user
 RUN addgroup -S app && adduser app -S -G app
 RUN chown app /home/app
 

--- a/template/python3-http-debian/Dockerfile
+++ b/template/python3-http-debian/Dockerfile
@@ -1,5 +1,7 @@
 ARG PYTHON_VERSION=3.12
 ARG DEBIAN_OS=slim-bookworm
+
+
 FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.10.4 AS watchdog
 FROM --platform=${TARGETPLATFORM:-linux/amd64} python:${PYTHON_VERSION}-${DEBIAN_OS} AS build
 
@@ -8,9 +10,11 @@ RUN chmod +x /usr/bin/fwatchdog
 
 ARG ADDITIONAL_PACKAGE
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
+ARG UPGRADE_PACKAGES=false
 
-RUN apt-get -qy update \
-    && apt-get -qy install ${ADDITIONAL_PACKAGE} \
+RUN apt-get update -qy \
+    && if [ "${UPGRADE_PACKAGES}" = "true" ] || [ "${UPGRADE_PACKAGES}" = "1" ]; then apt-get upgrade -qy; fi \
+    && apt-get install -qy --no-install-recommends gcc make ${ADDITIONAL_PACKAGE} \
     && rm -rf /var/lib/apt/lists/*
 
 # Add non root user

--- a/template/python3-http/Dockerfile
+++ b/template/python3-http/Dockerfile
@@ -5,10 +5,12 @@ FROM --platform=${TARGETPLATFORM:-linux/amd64} python:${PYTHON_VERSION}-alpine A
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
+ARG UPGRADE_PACKAGES
 ARG ADDITIONAL_PACKAGE
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 
-RUN apk --no-cache add ${ADDITIONAL_PACKAGE}
+RUN if [ "${UPGRADE_PACKAGES}" = "true" ] || [ "${UPGRADE_PACKAGES}" = "1" ]; then apk --no-cache upgrade; fi && \
+    apk --no-cache add ${ADDITIONAL_PACKAGE}
 
 # Add non root user
 RUN addgroup -S app && adduser app -S -G app


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Add UPGRADE_PACKAGES for Debian-based templates

## Motivation and Context

The UPGRADE_PACKAGES build_arg will invoke an apt upgrade to help with warnings generated from CVE / image scanners.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Example:

```yaml
version: 1.0
provider:
  name: openfaas
  gateway: https://openfaas.o6s.io
functions:
  updated:
    lang: python3-http-debian
    handler: ./updated
    image: ttl.sh/updated:latest
    build_args:
      UPGRADE_PACKAGES: "1"
```

Toggling `UPGRADE_PACKAGES` with `1/0` or `true/false` results in a rebuild and updated packages for the positive case.

Additionally, the Alpine templates support the same behaviour:

```yaml
version: 1.0
provider:
  name: openfaas
  gateway: https://openfaas.o6s.io
functions:
  updated-flask:
    lang: python3-flask
    handler: ./updated-flask
    image: ttl.sh/updated-flask:latest

    build_args:
      UPGRADE_PACKAGES: "1"
      ADDITIONAL_PACKAGE: "curl"
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

An update will be needed in the docs